### PR TITLE
Change api docs update to push changes to new branch instead

### DIFF
--- a/.github/workflows/generate-api-docs.yaml
+++ b/.github/workflows/generate-api-docs.yaml
@@ -38,4 +38,4 @@ jobs:
                   commit_message: Apply api docs updates
                   branch: update-api-docs
                   file_pattern: public/api-docs/*
-                  push_options: '-u'
+                  checkout_options: '-b'

--- a/.github/workflows/generate-api-docs.yaml
+++ b/.github/workflows/generate-api-docs.yaml
@@ -38,3 +38,4 @@ jobs:
                   commit_message: Apply api docs updates
                   branch: update-api-docs
                   file_pattern: public/api-docs/*
+                  push_options: '-u'

--- a/.github/workflows/generate-api-docs.yaml
+++ b/.github/workflows/generate-api-docs.yaml
@@ -36,3 +36,5 @@ jobs:
               uses: stefanzweifel/git-auto-commit-action@v4
               with:
                   commit_message: Apply api docs updates
+                  branch: update-api-docs
+                  file_pattern: public/api-docs/*


### PR DESCRIPTION
# Types of changes in this PR

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change of an existing feature
-   [ ] Refactor/Performance enhancements
-   [ ] Infra/Config changes

# Overview (attach screenshots if necessary)

- Currently, the generate api docs CI is triggered on review request or when the `Ready to Review` button is clicked on github. Sometimes, the PR author has not updated his PR branch to the latest changes on master.
- This may cause the api docs to have a merge conflict, and cause an error on the CI.
- Hence, this CI now pushes to a separate remote branch, and a PR can be created purely for updates to API documentation. This also gives us the autonomy to review the changes in documentation before it is merged, hence, ensuring that the changes are vetted.
